### PR TITLE
fix: avoiding leaving constructor empty

### DIFF
--- a/src/rules/deny-constructor-di.ts
+++ b/src/rules/deny-constructor-di.ts
@@ -54,23 +54,22 @@ const rule: TSESLint.RuleModule<'denyConstructorDI', []> = {
             (token) => token === closeToken
           );
 
-          const openContentToken = node.tokens
+          const openBlockToken = node.tokens
             .filter((token) => token.loc.start.line >= startLine)
             .find((token) => token.value === '{');
 
-          const closeContentToken = node.tokens
+          const closeBlockToken = node.tokens
             .filter((token) => token.loc.start.line >= startLine)
             .find((token) => token.value === '}');
 
-          const openContentIndex = node.tokens.findIndex(
-            (token) => token === openContentToken
+          const openBlockIndex = node.tokens.findIndex(
+            (token) => token === openBlockToken
           );
 
-          const closeContentIndex = node.tokens.findIndex(
-            (token) => token === closeContentToken
+          const closeBlockIndex = node.tokens.findIndex(
+            (token) => token === closeBlockToken
           );
-          const constructorContentIsEmpty =
-            closeContentIndex === openContentIndex + 1;
+          const isEmptyBlock = closeBlockIndex === openBlockIndex + 1;
 
           if (openToken && closeToken) {
             const diToken = node.tokens.filter(
@@ -119,7 +118,7 @@ const rule: TSESLint.RuleModule<'denyConstructorDI', []> = {
                 }
               }
 
-              if (!constructorContentIsEmpty) {
+              if (!isEmptyBlock) {
                 codes.push('');
                 codes.push('constructor(');
               }
@@ -128,8 +127,8 @@ const rule: TSESLint.RuleModule<'denyConstructorDI', []> = {
                 node: constructor,
                 messageId: 'denyConstructorDI',
                 fix: (fixer) => {
-                  const endRange = constructorContentIsEmpty
-                    ? closeContentToken!.range[1]
+                  const endRange = isEmptyBlock
+                    ? closeBlockToken!.range[1]
                     : closeToken.range[0];
 
                   return fixer.replaceTextRange(

--- a/src/rules/deny-constructor-di.ts
+++ b/src/rules/deny-constructor-di.ts
@@ -54,6 +54,24 @@ const rule: TSESLint.RuleModule<'denyConstructorDI', []> = {
             (token) => token === closeToken
           );
 
+          const openContentToken = node.tokens
+            .filter((token) => token.loc.start.line >= startLine)
+            .find((token) => token.value === '{');
+
+          const closeContentToken = node.tokens
+            .filter((token) => token.loc.start.line >= startLine)
+            .find((token) => token.value === '}');
+
+          const openContentIndex = node.tokens.findIndex(
+            (token) => token === openContentToken
+          );
+
+          const closeContentIndex = node.tokens.findIndex(
+            (token) => token === closeContentToken
+          );
+          const constructorContentIsEmpty =
+            closeContentIndex === openContentIndex + 1;
+
           if (openToken && closeToken) {
             const diToken = node.tokens.filter(
               (token, index) =>
@@ -101,15 +119,21 @@ const rule: TSESLint.RuleModule<'denyConstructorDI', []> = {
                 }
               }
 
-              codes.push('');
-              codes.push('constructor(');
+              if (!constructorContentIsEmpty) {
+                codes.push('');
+                codes.push('constructor(');
+              }
 
               context.report({
                 node: constructor,
                 messageId: 'denyConstructorDI',
                 fix: (fixer) => {
+                  const endRange = constructorContentIsEmpty
+                    ? closeContentToken!.range[1]
+                    : closeToken.range[0];
+
                   return fixer.replaceTextRange(
-                    [constructor.range[0], closeToken.range[0]],
+                    [constructor.range[0], endRange],
                     codes.join('\n' + ' '.repeat(constructor.loc.start.column))
                   );
                 },

--- a/tests/rules/deny-costructor-di.ts
+++ b/tests/rules/deny-costructor-di.ts
@@ -88,8 +88,6 @@ new TSESLint.RuleTester().run('deny-custructor-di', rule, {
           private store = inject(Store);
           private readonly navCtrl = inject(NavController);
           public readonly helper = inject(HelperService);
-          
-          constructor() {}
         }
       `,
       parser: require.resolve('@typescript-eslint/parser'),
@@ -118,8 +116,6 @@ new TSESLint.RuleTester().run('deny-custructor-di', rule, {
         })
         export class SigninPage {
           public platform = inject(Platform);
-          
-          constructor() {}
         }
       `,
       parser: require.resolve('@typescript-eslint/parser'),
@@ -148,8 +144,6 @@ new TSESLint.RuleTester().run('deny-custructor-di', rule, {
         })
         export class SigninPage {
           private platform = inject(Platform);
-          
-          constructor() {}
         }
       `,
       parser: require.resolve('@typescript-eslint/parser'),
@@ -178,8 +172,6 @@ new TSESLint.RuleTester().run('deny-custructor-di', rule, {
         })
         export class ConfirmPage {
           public readonly platform = inject(Platform);
-          
-          constructor() {}
         }
       `,
       parser: require.resolve('@typescript-eslint/parser'),


### PR DESCRIPTION
If you use the lint rules `@typescript-eslint/no-useless-constructor` and `@typescript-eslint/no-empty-function` in your project, you may encounter lint errors after running the fix command.