### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rdlabo/eslint-plugin-rules",
+  "private": false,
   "version": "21.0.1-1",
   "description": "",
   "engines": {


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.