### PR TITLE
Add typed try block restriction rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module.exports = tseslint.config(
 
 `rdlabo.configs.recommended` enables the fleet-common `@rdlabo/rules/*` preset:
 
-- TypeScript: `signal-use-as-signal`, `signal-use-as-signal-template`, `deny-import-from-ionic-module`, `implements-ionic-lifecycle`, `deny-soft-private-modifier`, `deny-overlay-create`, `prefer-modal-launcher`, `require-viewmodel`, `component-property-use-readonly` (`ignorePrivateProperties: true`), `no-component-method-except-lifecycle`
+- TypeScript: `signal-use-as-signal`, `signal-use-as-signal-template`, `deny-import-from-ionic-module`, `implements-ionic-lifecycle`, `deny-soft-private-modifier`, `deny-overlay-create`, `prefer-modal-launcher`, `require-viewmodel`, `component-property-use-readonly` (`ignorePrivateProperties: true`), `no-component-method-except-lifecycle`, `restrict-try-block` (`allowPromise: false`, `allowRxjs: false`, `allowInSignal: false`, `maxLines: 3`)
 - Templates: `ionic-attr-type-check`, `deny-element` (common Ionic overlay tags), `prefer-disable-handler`
 
 `deny-constructor-di` is **not** included (deprecated; prefer Angular `inject()` migration).
@@ -81,6 +81,7 @@ const rdlabo = require('@rdlabo/eslint-plugin-rules');
 module.exports = tseslint.config(
   {
     files: ['**/*.ts'],
+    languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: __dirname } },
     plugins: {
       '@rdlabo/rules': rdlabo,
     },
@@ -95,6 +96,7 @@ module.exports = tseslint.config(
       '@rdlabo/rules/signal-use-as-signal': 'error',
       '@rdlabo/rules/signal-use-as-signal-template': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {
@@ -117,23 +119,30 @@ module.exports = tseslint.config(
 
 ## 📋 Available Rules
 
-| Rule                                                                                                     | Description                                                            | Auto-fixable |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | :----------: |
-| [@rdlabo/rules/deny-constructor-di](docs/rules/deny-constructor-di.md)                                   | Prevents Dependency Injection within constructors                      |      ❌      |
-| [@rdlabo/rules/deny-element](docs/rules/deny-element.md)                                                 | Restricts usage of specific HTML elements                              |      ❌      |
-| [@rdlabo/rules/deny-import-from-ionic-module](docs/rules/deny-import-from-ionic-module.md)               | Prevents direct imports from `@ionic/angular`                          |      ✅      |
-| [@rdlabo/rules/deny-overlay-create](docs/rules/deny-overlay-create.md)                                   | Disallows `.create()` on Modal/Popover controllers                     |      ❌      |
-| [@rdlabo/rules/prefer-modal-launcher](docs/rules/prefer-modal-launcher.md)                               | Requires `presentModal` calls inside `launch*` launcher functions      |      ❌      |
-| [@rdlabo/rules/require-viewmodel](docs/rules/require-viewmodel.md)                                       | Enforces `new ViewModel(this)` + `ViewModelStore<Component>`           |      ❌      |
-| [@rdlabo/rules/no-component-method-except-lifecycle](docs/rules/no-component-method-except-lifecycle.md) | Allow only lifecycle methods declared via `implements` on `@Component` |      ❌      |
-| [@rdlabo/rules/implements-ionic-lifecycle](docs/rules/implements-ionic-lifecycle.md)                     | Ensures proper implementation of Ionic lifecycle hooks                 |      ✅      |
-| [@rdlabo/rules/deny-soft-private-modifier](docs/rules/deny-soft-private-modifier.md)                     | Prevents usage of soft private modifiers                               |      ✅      |
-| [@rdlabo/rules/signal-use-as-signal](docs/rules/signal-use-as-signal.md)                                 | Validates proper usage of Angular signals                              |      ✅      |
-| [@rdlabo/rules/signal-use-as-signal-template](docs/rules/signal-use-as-signal-template.md)               | Enforces correct usage of Angular Signals in templates                 |      ❌      |
-| [@rdlabo/rules/component-property-use-readonly](docs/rules/component-property-use-readonly.md)           | Enforces readonly modifier for class properties                        |      ✅      |
-| [@rdlabo/rules/ionic-attr-type-check](docs/rules/ionic-attr-type-check.md)                               | Disallows string values for non-string attributes in Ionic components  |      ✅      |
+<!--RULE_TABLE_BEGIN-->
 
-`@rdlabo/rules/import-inject-object` is removed. This is because we removed the auto-fixable feature from `@rdlabo/rules/deny-constructor-di` due to concerns about its compatibility with the new `ng generate @angular/core:inject` command.
+| Rule                                                                                                       | Description                                                                                                                                                       | Auto-fixable |
+| :--------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: |
+| [@rdlabo/rules/component-property-use-readonly](./docs/rules/component-property-use-readonly.md)           | Warns when a property should be readonly                                                                                                                          |      ✅      |
+| [@rdlabo/rules/deny-constructor-di](./docs/rules/deny-constructor-di.md)                                   | This plugin disallows Dependency Injection within the constructor.                                                                                                |      ❌      |
+| [@rdlabo/rules/deny-element](./docs/rules/deny-element.md)                                                 | This plugin disallows the use of certain HTML tags.                                                                                                               |      ❌      |
+| [@rdlabo/rules/deny-import-from-ionic-module](./docs/rules/deny-import-from-ionic-module.md)               | This plugin prevents accidental imports from @ionic/angular instead of @ionic/angular/standalone.                                                                 |      ✅      |
+| [@rdlabo/rules/deny-overlay-create](./docs/rules/deny-overlay-create.md)                                   | Disallow `.create()` on ModalController / PopoverController; open overlays via launchers instead.                                                                 |      ❌      |
+| [@rdlabo/rules/deny-soft-private-modifier](./docs/rules/deny-soft-private-modifier.md)                     | This plugin disallows the use of soft private modifier.                                                                                                           |      ✅      |
+| [@rdlabo/rules/implements-ionic-lifecycle](./docs/rules/implements-ionic-lifecycle.md)                     | This plugin recommend to implements Ionic Lifecycle.                                                                                                              |      ✅      |
+| [@rdlabo/rules/ionic-attr-type-check](./docs/rules/ionic-attr-type-check.md)                               | Disallows string values for non-string attributes in Ionic components and suggests proper property binding. Supports boolean, number, and object type attributes. |      ✅      |
+| [@rdlabo/rules/no-component-method-except-lifecycle](./docs/rules/no-component-method-except-lifecycle.md) | Disallow non-lifecycle methods on `@Component`. Allowed lifecycle methods are derived from `implements` (properties are allowed).                                 |      ❌      |
+| [@rdlabo/rules/no-component-writable-signal](./docs/rules/no-component-writable-signal.md)                 | Keep writable component state in ViewModel, except models passed to Angular Signal Forms `form()`.                                                                |      ❌      |
+| [@rdlabo/rules/no-reactive-forms](./docs/rules/no-reactive-forms.md)                                       | Disallow Angular Reactive Forms in favor of Signal Forms.                                                                                                         |      ❌      |
+| [@rdlabo/rules/no-template-driven-forms](./docs/rules/no-template-driven-forms.md)                         | Disallow template-driven forms except `ngModel` bindings on explicitly allowed elements.                                                                          |      ❌      |
+| [@rdlabo/rules/prefer-disable-handler](./docs/rules/prefer-disable-handler.md)                             | Require a wrapper method (default: disableHandler($event, work)) on configured element/event bindings to prevent double taps while async work runs                |      ❌      |
+| [@rdlabo/rules/prefer-modal-launcher](./docs/rules/prefer-modal-launcher.md)                               | Require `presentModal` calls to live inside a `launch*` launcher function.                                                                                        |      ❌      |
+| [@rdlabo/rules/require-viewmodel](./docs/rules/require-viewmodel.md)                                       | Enforce Component `new ViewModel(this)`, `ViewModelStore<ComponentType, Keys>` inheritance, and keep View APIs off ViewModel.                                     |      ❌      |
+| [@rdlabo/rules/restrict-try-block](./docs/rules/restrict-try-block.md)                                     | Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.                                                                       |      ❌      |
+| [@rdlabo/rules/signal-use-as-signal-template](./docs/rules/signal-use-as-signal-template.md)               | Require () when accessing Angular Signals in templates                                                                                                            |      ❌      |
+| [@rdlabo/rules/signal-use-as-signal](./docs/rules/signal-use-as-signal.md)                                 | This plugin check to valid signal use as signal.                                                                                                                  |      ✅      |
+
+<!--RULE_TABLE_END-->
 
 ## 🔧 Recommended Additional Rules
 

--- a/docs/rules/restrict-try-block.md
+++ b/docs/rules/restrict-try-block.md
@@ -1,0 +1,62 @@
+# @rdlabo/rules/restrict-try-block
+
+> Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.
+>
+> - ⭐️ This rule is included in `plugin:@rdlabo/rules/recommended` preset.
+
+Restricts asynchronous/reactive processing and physical code lines inside `try` blocks.
+
+## Rule Details
+
+This rule keeps `try` as a small boundary for synchronous exceptions. By default it reports:
+
+- `await` and expressions whose TypeScript type is Promise-like
+- expressions whose type or base type is declared by the `rxjs` package, including `Observable` and `Subject` variants
+- `try` statements inside Angular `computed()` and `effect()` callbacks
+- `try` bodies containing more than three physical code lines
+
+Only the `try` body is inspected. Its `catch` and `finally` clauses are not. Nested functions, classes, and nested `try` statements are separate execution boundaries and are not attributed to the outer `try`.
+
+Promise rejections should normally be handled by a Promise error boundary such as `.catch()`. If a Promise producer can also throw synchronously, preserve that boundary explicitly:
+
+```ts
+Promise.resolve()
+  .then(() => makePromise())
+  .catch(handleError);
+```
+
+RxJS errors should be handled through the Observable error channel, such as `catchError()` or an explicit subscriber error handler.
+
+This is a type-aware rule. Configure typed linting, for example:
+
+```js
+languageOptions: {
+  parserOptions: {
+    projectService: true,
+    tsconfigRootDir: __dirname,
+  },
+},
+```
+
+## Options
+
+```js
+{
+  allowPromise: false,
+  allowRxjs: false,
+  allowInSignal: false,
+  maxLines: 3,
+}
+```
+
+- `allowPromise`: Allow Promise-like processing and `await` inside `try`.
+- `allowRxjs`: Allow values and operations backed by types declared by `rxjs`. This includes `Observable`, `Subject`, and their subclasses.
+- `allowInSignal`: Allow `try` inside inline Angular `computed()` and `effect()` callbacks. Aliased and namespace imports from `@angular/core` are recognized. Nested function and class bodies are separate execution boundaries.
+- `maxLines`: Maximum physical code lines in the `try` body, or `false` to disable the size check.
+
+For `maxLines`, the outer braces, comments, and blank lines are excluded. A unique physical line containing any other token counts once. Internal braces and multiline tokens count, so formatting can affect the result intentionally: the rule keeps the boundary visually small as well as logically narrow.
+
+## Implementation
+
+- [Rule source](../../src/rules/restrict-try-block.ts)
+- [Test source](../../tests/rules/restrict-try-block.ts)

--- a/docs/rules/signal-use-as-signal-template.md
+++ b/docs/rules/signal-use-as-signal-template.md
@@ -1,5 +1,7 @@
 # @rdlabo/rules/signal-use-as-signal-template
 
+> Require () when accessing Angular Signals in templates
+>
 > - ⭐️ This rule is included in `plugin:@rdlabo/rules/recommended` preset.
 
 This rule ensures that Signals are properly accessed in templates by requiring the use of the function call syntax `()`. This is necessary because Signals in Angular are functions that need to be called to access their current value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "21.2.4",
       "license": "MIT",
       "dependencies": {
-        "@ionic/angular": "> 8.0.0"
+        "@ionic/angular": "> 8.0.0",
+        "ts-api-utils": "2.1.0"
       },
       "devDependencies": {
         "@angular-eslint/template-parser": "^21.0.0",
@@ -18,7 +19,7 @@
         "@types/eslint": "^9.0.0",
         "@types/jest": "^29.5.0",
         "@typescript-eslint/rule-tester": "^8.33.0",
-        "@typescript-eslint/utils": "^8.33.0",
+        "@typescript-eslint/utils": "8.50.0",
         "eslint": "^9.0.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -27,6 +28,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.4",
         "rimraf": "^5.0.0",
+        "rxjs": "^7.8.2",
         "ts-jest": "^29.2.4",
         "ts-node": "^10.9.0",
         "typescript": "^5.8.0",
@@ -36,6 +38,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@typescript-eslint/utils": ">=8.33.0 <9.0.0",
         "eslint": ">=9.0.0"
       }
     },
@@ -743,9 +746,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11425,7 +11428,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -11668,7 +11670,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "inspect": "npx @eslint/config-inspector"
   },
   "peerDependencies": {
+    "@typescript-eslint/utils": ">=8.33.0 <9.0.0",
     "eslint": ">=9.0.0"
   },
   "devDependencies": {
@@ -40,7 +41,7 @@
     "@types/eslint": "^9.0.0",
     "@types/jest": "^29.5.0",
     "@typescript-eslint/rule-tester": "^8.33.0",
-    "@typescript-eslint/utils": "^8.33.0",
+    "@typescript-eslint/utils": "8.50.0",
     "eslint": "^9.0.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -49,6 +50,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.4",
     "rimraf": "^5.0.0",
+    "rxjs": "^7.8.2",
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.0",
     "typescript": "^5.8.0",
@@ -79,6 +81,7 @@
     "url": "https://github.com/rdlabo-team/eslint-plugin-rules/issues"
   },
   "dependencies": {
-    "@ionic/angular": "> 8.0.0"
+    "@ionic/angular": "> 8.0.0",
+    "ts-api-utils": "2.1.0"
   }
 }

--- a/scripts/lib/recommended-rule-names.ts
+++ b/scripts/lib/recommended-rule-names.ts
@@ -10,6 +10,7 @@ export const RECOMMENDED_RULE_NAMES = new Set([
   'require-viewmodel',
   'component-property-use-readonly',
   'no-component-method-except-lifecycle',
+  'restrict-try-block',
   'ionic-attr-type-check',
   'deny-element',
   'prefer-disable-handler',

--- a/scripts/lib/rules.ts
+++ b/scripts/lib/rules.ts
@@ -10,7 +10,6 @@ export interface RuleInfo {
   filePath: string;
   id: string;
   name: string;
-  category: string;
   description: string;
   recommended: RuleRecommendation | false;
   deprecated: boolean;
@@ -18,19 +17,15 @@ export interface RuleInfo {
   replacedBy: string[];
 }
 
-export interface CategoryInfo {
-  id: string;
-  rules: RuleInfo[];
-}
-
 export const rules: RuleInfo[] = readdirSync(rootDir)
-  .filter((filename) => filename.endsWith('.ts') && !filename.includes('types') && !filename.includes('utils'))
+  .filter((filename) => filename.endsWith('.ts') && filename !== 'types.ts' && filename !== 'utils.ts')
   .sort()
   .map((filename): RuleInfo => {
     const filePath = join(rootDir, filename);
     const name = filename.slice(0, -3);
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const rule = require(filePath);
+    const loadedRule = require(filePath);
+    const rule = loadedRule.default ?? loadedRule;
 
     return {
       filePath,
@@ -39,13 +34,7 @@ export const rules: RuleInfo[] = readdirSync(rootDir)
       deprecated: Boolean(rule.meta?.deprecated),
       fixable: Boolean(rule.meta?.fixable),
       replacedBy: [],
-      category: rule.meta?.docs?.category ?? '',
       description: rule.meta?.docs?.description ?? '',
       recommended: RECOMMENDED_RULE_NAMES.has(name) ? 'recommended' : false,
     };
   });
-
-export const categories: CategoryInfo[] = ['Possible Errors', 'Best Practices', 'Stylistic Issues'].map((id): CategoryInfo => ({
-  id,
-  rules: rules.filter((rule) => rule.category === id && !rule.deprecated),
-}));

--- a/scripts/lib/update-lib-configs-recommended.ts
+++ b/scripts/lib/update-lib-configs-recommended.ts
@@ -32,6 +32,7 @@ const recommended: Linter.Config[] = [
       '@rdlabo/rules/require-viewmodel': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
       '@rdlabo/rules/no-component-method-except-lifecycle': 'error',
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {

--- a/scripts/lib/update-readme.ts
+++ b/scripts/lib/update-readme.ts
@@ -1,38 +1,35 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
-import type { CategoryInfo, RuleInfo } from './rules';
-import { categories } from './rules';
+import type { RuleInfo } from './rules';
+import { rules } from './rules';
 
-/**
- * Render a given rule as a table row.
- */
-function renderRule(rule: RuleInfo): string {
-  const mark = `${rule.recommended ? '⭐️' : ''}${rule.fixable ? '✒️' : ''}`;
+function ruleCells(rule: RuleInfo): string[] {
   const link = `[${rule.id}](./docs/rules/${rule.name}.md)`;
   const description = rule.description || '(no description)';
 
-  return `| ${link} | ${description} | ${mark} |`;
-}
-
-/**
- * Render a given category as a section.
- */
-function renderCategory(category: CategoryInfo): string {
-  if (category.rules.length === 0) {
-    return '';
-  }
-  return `### ${category.id}
-
-| Rule ID | Description |    |
-|:--------|:------------|:--:|
-${category.rules.map(renderRule).join('\n')}
-`;
+  return [link, description, rule.fixable ? '✅' : '❌'];
 }
 
 const filePath = resolve(__dirname, '../../README.md');
-const content = categories.map(renderCategory).filter(Boolean).join('\n');
+const headers = ['Rule', 'Description', 'Auto-fixable'];
+const rows = rules.map(ruleCells);
+const widths = headers.map((header, index) => Math.max(header.length, ...rows.map((row) => row[index].length)));
+const renderCell = (cell: string, index: number) => {
+  if (index !== 2 || cell === headers[index]) {
+    return cell.padEnd(widths[index]);
+  }
+  const displayWidth = cell === '✅' || cell === '❌' ? 2 : cell.length;
+  const padding = widths[index] - displayWidth;
+  return `${' '.repeat(Math.ceil(padding / 2))}${cell}${' '.repeat(Math.floor(padding / 2))}`;
+};
+const renderRow = (cells: string[]) => `| ${cells.map(renderCell).join(' | ')} |`;
+const divider = `| ${widths.map((width, index) => (index === 2 ? `:${'-'.repeat(width - 2)}:` : `:${'-'.repeat(width - 1)}`)).join(' | ')} |`;
+const content = [renderRow(headers), divider, ...rows.map(renderRow)].join('\n');
 
 writeFileSync(
   filePath,
-  readFileSync(filePath, 'utf8').replace(/<!--RULE_TABLE_BEGIN-->[\s\S]*<!--RULE_TABLE_END-->/u, `<!--RULE_TABLE_BEGIN-->\n${content}\n<!--RULE_TABLE_END-->`),
+  readFileSync(filePath, 'utf8').replace(
+    /<!--RULE_TABLE_BEGIN-->[\s\S]*<!--RULE_TABLE_END-->/u,
+    `<!--RULE_TABLE_BEGIN-->\n\n${content}\n\n<!--RULE_TABLE_END-->`,
+  ),
 );

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -21,6 +21,7 @@ const recommended: Linter.Config[] = [
       '@rdlabo/rules/require-viewmodel': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
       '@rdlabo/rules/no-component-method-except-lifecycle': 'error',
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import notemplatedrivenforms from './rules/no-template-driven-forms';
 import preferdisablehandler from './rules/prefer-disable-handler';
 import prefermodallauncher from './rules/prefer-modal-launcher';
 import requireviewmodel from './rules/require-viewmodel';
+import restricttryblock from './rules/restrict-try-block';
 import signaluseassignaltemplate from './rules/signal-use-as-signal-template';
 import signaluseassignal from './rules/signal-use-as-signal';
 
@@ -39,6 +40,7 @@ export = {
     'prefer-disable-handler': preferdisablehandler,
     'prefer-modal-launcher': prefermodallauncher,
     'require-viewmodel': requireviewmodel,
+    'restrict-try-block': restricttryblock,
     'signal-use-as-signal-template': signaluseassignaltemplate,
     'signal-use-as-signal': signaluseassignal,
   },

--- a/src/rules/restrict-try-block.ts
+++ b/src/rules/restrict-try-block.ts
@@ -1,0 +1,262 @@
+import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { Type } from 'typescript';
+import { isIntrinsicAnyType, isIntrinsicUnknownType, isThenableType } from 'ts-api-utils';
+
+type MessageIds = 'promiseNotAllowed' | 'rxjsNotAllowed' | 'signalContextNotAllowed' | 'tooManyLines';
+
+interface RuleOptions {
+  allowPromise?: boolean;
+  allowRxjs?: boolean;
+  allowInSignal?: boolean;
+  maxLines?: number | false;
+}
+
+type Options = [RuleOptions?];
+
+const DEFAULT_OPTIONS: Required<RuleOptions> = {
+  allowPromise: false,
+  allowRxjs: false,
+  allowInSignal: false,
+  maxLines: 3,
+};
+
+function isTraversalBoundary(node: TSESTree.Node): boolean {
+  return (
+    node.type === 'TryStatement' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'ClassDeclaration' ||
+    node.type === 'ClassExpression'
+  );
+}
+
+function isRelevantExpression(node: TSESTree.Node): node is TSESTree.Identifier | TSESTree.MemberExpression | TSESTree.CallExpression | TSESTree.NewExpression {
+  return node.type === 'Identifier' || node.type === 'MemberExpression' || node.type === 'CallExpression' || node.type === 'NewExpression';
+}
+
+function isUnsafeTopType(type: Type): boolean {
+  return isIntrinsicAnyType(type) || isIntrinsicUnknownType(type);
+}
+
+function typeParts(type: Type): readonly Type[] {
+  return type.isUnionOrIntersection() ? type.types : [type];
+}
+
+function declarationComesFromRxjs(type: Type): boolean {
+  const symbols = [type.aliasSymbol, type.getSymbol()].filter((symbol) => symbol !== undefined);
+  return symbols.some((symbol) =>
+    symbol.declarations?.some((declaration) => {
+      const fileName = declaration.getSourceFile().fileName.replace(/\\/g, '/');
+      return fileName.includes('/node_modules/rxjs/');
+    }),
+  );
+}
+
+const rule: TSESLint.RuleModule<MessageIds, Options> = {
+  defaultOptions: [DEFAULT_OPTIONS],
+  meta: {
+    docs: {
+      description: 'Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.',
+      url: '',
+    },
+    messages: {
+      promiseNotAllowed:
+        'Promise/thenable processing is not allowed inside a try block. Use a Promise error boundary such as `.catch()`; wrap the producer in `Promise.resolve().then()` when it may throw synchronously.',
+      rxjsNotAllowed:
+        'RxJS processing is not allowed inside a try block. Handle its error channel with `catchError()` or an explicit subscriber error handler.',
+      signalContextNotAllowed:
+        'A try block is not allowed inside an Angular `computed()` or `effect()` callback. Extract fallible synchronous work into a safe function outside the reactive context.',
+      tooManyLines: 'This try block contains {{actual}} physical code lines; the configured maximum is {{max}}.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowPromise: { type: 'boolean' },
+          allowRxjs: { type: 'boolean' },
+          allowInSignal: { type: 'boolean' },
+          maxLines: {
+            anyOf: [
+              { type: 'integer', minimum: 1 },
+              { type: 'boolean', enum: [false] },
+            ],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    type: 'problem',
+  },
+  create(context) {
+    const options = { ...DEFAULT_OPTIONS, ...context.options[0] };
+    const sourceCode = context.sourceCode;
+    const needsTypeInformation = !options.allowPromise || !options.allowRxjs;
+    const services = needsTypeInformation ? ESLintUtils.getParserServices(context) : null;
+    const checker = services?.program.getTypeChecker();
+    const angularSignalCallbacks = new Set(['computed', 'effect']);
+    const angularSignalNames = new Set<string>();
+    const angularCoreNamespaces = new Set<string>();
+
+    for (const statement of sourceCode.ast.body) {
+      if (statement.type !== 'ImportDeclaration' || statement.source.value !== '@angular/core') {
+        continue;
+      }
+      for (const specifier of statement.specifiers) {
+        if (specifier.type === 'ImportNamespaceSpecifier') {
+          angularCoreNamespaces.add(specifier.local.name);
+        } else if (specifier.type === 'ImportSpecifier') {
+          const importedName = specifier.imported.type === 'Identifier' ? specifier.imported.name : specifier.imported.value;
+          if (angularSignalCallbacks.has(importedName)) {
+            angularSignalNames.add(specifier.local.name);
+          }
+        }
+      }
+    }
+
+    function isPromiseLike(node: TSESTree.Node, type: Type): boolean {
+      if (!checker || !services || isUnsafeTopType(type)) {
+        return false;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      return isThenableType(checker, tsNode, type);
+    }
+
+    function isRxjsType(type: Type, seen = new Set<Type>()): boolean {
+      if (isUnsafeTopType(type) || seen.has(type)) {
+        return false;
+      }
+      seen.add(type);
+      return typeParts(type).some((part) => {
+        if (part !== type && isRxjsType(part, seen)) {
+          return true;
+        }
+        if (declarationComesFromRxjs(part)) {
+          return true;
+        }
+        return (part.getBaseTypes() ?? []).some((baseType) => isRxjsType(baseType, seen));
+      });
+    }
+
+    function codeLineCount(block: TSESTree.BlockStatement): number {
+      const tokens = sourceCode.getTokens(block, { includeComments: false });
+      const codeLines = new Set<number>();
+
+      // The first and last tokens are the try block's own braces. Braces inside
+      // the block remain code and therefore count toward the physical line limit.
+      for (const token of tokens.slice(1, -1)) {
+        for (let line = token.loc.start.line; line <= token.loc.end.line; line += 1) {
+          codeLines.add(line);
+        }
+      }
+      return codeLines.size;
+    }
+
+    function isAngularSignalCall(node: TSESTree.Node | undefined): boolean {
+      if (!node || node.type !== 'CallExpression') {
+        return false;
+      }
+      if (node.callee.type === 'Identifier') {
+        return angularSignalNames.has(node.callee.name);
+      }
+      return (
+        node.callee.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.object.type === 'Identifier' &&
+        angularCoreNamespaces.has(node.callee.object.name) &&
+        node.callee.property.type === 'Identifier' &&
+        angularSignalCallbacks.has(node.callee.property.name)
+      );
+    }
+
+    function isInsideAngularSignalCallback(node: TSESTree.TryStatement): boolean {
+      let current: TSESTree.Node | undefined = node.parent;
+      while (current) {
+        if (current.type === 'FunctionDeclaration' || current.type === 'FunctionExpression' || current.type === 'ArrowFunctionExpression') {
+          const parent = current.parent;
+          return parent?.type === 'CallExpression' && isAngularSignalCall(parent) && parent.arguments[0] === current;
+        }
+        if (current.type === 'ClassDeclaration' || current.type === 'ClassExpression') {
+          return false;
+        }
+        current = current.parent;
+      }
+      return false;
+    }
+
+    function inspectTryBlock(block: TSESTree.BlockStatement): { promiseNode?: TSESTree.Node; rxjsNode?: TSESTree.Node } {
+      let promiseNode: TSESTree.Node | undefined;
+      let rxjsNode: TSESTree.Node | undefined;
+
+      function visit(node: TSESTree.Node, isRoot = false): void {
+        if (!isRoot && isTraversalBoundary(node)) {
+          return;
+        }
+
+        if (!options.allowPromise && !promiseNode && node.type === 'AwaitExpression') {
+          promiseNode = node;
+        }
+
+        if (services && checker && isRelevantExpression(node) && ((!options.allowPromise && !promiseNode) || (!options.allowRxjs && !rxjsNode))) {
+          const type = services.getTypeAtLocation(node);
+          if (!options.allowPromise && !promiseNode && isPromiseLike(node, type)) {
+            promiseNode = node;
+          }
+          if (!options.allowRxjs && !rxjsNode && isRxjsType(type)) {
+            rxjsNode = node;
+          }
+        }
+
+        if (!options.allowPromise || !promiseNode || !options.allowRxjs || !rxjsNode) {
+          const keys = sourceCode.visitorKeys[node.type] ?? [];
+          const record = node as unknown as Record<string, unknown>;
+          for (const key of keys) {
+            const value = record[key];
+            if (Array.isArray(value)) {
+              for (const child of value) {
+                if (child && typeof child === 'object' && 'type' in child) {
+                  visit(child as TSESTree.Node);
+                }
+              }
+            } else if (value && typeof value === 'object' && 'type' in value) {
+              visit(value as TSESTree.Node);
+            }
+          }
+        }
+      }
+
+      visit(block, true);
+      return { promiseNode, rxjsNode };
+    }
+
+    return {
+      TryStatement(node) {
+        const { promiseNode, rxjsNode } = inspectTryBlock(node.block);
+
+        if (!options.allowInSignal && isInsideAngularSignalCallback(node)) {
+          context.report({ node, messageId: 'signalContextNotAllowed' });
+        }
+
+        if (promiseNode) {
+          context.report({ node: promiseNode, messageId: 'promiseNotAllowed' });
+        }
+        if (rxjsNode) {
+          context.report({ node: rxjsNode, messageId: 'rxjsNotAllowed' });
+        }
+
+        if (options.maxLines !== false) {
+          const actual = codeLineCount(node.block);
+          if (actual > options.maxLines) {
+            context.report({
+              node: node.block,
+              messageId: 'tooManyLines',
+              data: { actual, max: options.maxLines },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export = rule;

--- a/tests/rules/restrict-try-block.ts
+++ b/tests/rules/restrict-try-block.ts
@@ -1,0 +1,354 @@
+import { RuleTester } from '@angular-eslint/test-utils';
+import { Linter, Rule } from 'eslint';
+import { resolve } from 'path';
+import { parser } from 'typescript-eslint';
+import rule from '../../src/rules/restrict-try-block';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: { allowDefaultProject: ['file.ts'] },
+      tsconfigRootDir: resolve(__dirname, '../..'),
+    },
+  },
+});
+
+const allowOnlySizeCheck = [{ allowPromise: true, allowRxjs: true, allowInSignal: true }] as const;
+const allowOnlySignalCheck = [{ allowPromise: true, allowRxjs: true, maxLines: false }] as const;
+
+ruleTester.run('restrict-try-block', rule, {
+  valid: [
+    `
+      function parse(source: string) {
+        try {
+          return JSON.parse(source);
+        } catch {
+          return null;
+        }
+      }
+    `,
+    {
+      code: `
+        declare function consume(value: unknown): void;
+        declare const anyValue: any;
+        declare const unknownValue: unknown;
+        try {
+          consume(anyValue);
+          consume(unknownValue);
+        } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        try {
+          const later = async () => Promise.resolve(1);
+          class Later { async run() { return Promise.resolve(2); } }
+        } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        function computed(callback: () => number): number { return callback(); }
+        computed(() => {
+          try { return 1; } catch { return 0; }
+        });
+      `,
+      options: allowOnlySignalCheck,
+    },
+    {
+      code: `
+        class Observable<T> { subscribe(): T { throw new Error(); } }
+        const source = new Observable<number>();
+        try { source.subscribe(); } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        import { computed } from '@angular/core';
+        computed(() => {
+          try { return JSON.parse('1'); } catch { return 0; }
+        });
+      `,
+      options: [{ allowPromise: true, allowRxjs: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        async function run() {
+          try { await Promise.resolve(1); } catch {}
+        }
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        import { of } from 'rxjs';
+        try { of(1).subscribe(); } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+    },
+    {
+      code: `
+        import { effect } from '@angular/core';
+        effect(() => {
+          const later = () => {
+            try { JSON.parse('bad'); } catch {}
+          };
+          later();
+        });
+      `,
+      options: allowOnlySignalCheck,
+    },
+    {
+      code: `
+        try {
+          run(); // inline comment
+
+          // comment-only line
+          finish();
+        } catch {}
+        declare function run(): void;
+        declare function finish(): void;
+      `,
+      options: allowOnlySizeCheck,
+    },
+    {
+      code: `
+        async function run() {
+          try { doWork(); } catch {
+            await Promise.resolve();
+          } finally {
+            Promise.resolve();
+          }
+        }
+        declare function doWork(): void;
+      `,
+    },
+    {
+      code: `
+        try { first(); second(); third(); } catch {}
+        declare function first(): void;
+        declare function second(): void;
+        declare function third(): void;
+      `,
+      options: [{ allowPromise: true, allowRxjs: true, allowInSignal: true, maxLines: 1 }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        async function run() {
+          try { await Promise.resolve(1); } catch {}
+        }
+      `,
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        type Work<T> = Promise<T>;
+        declare const work: Work<number>;
+        try { consume(work); } catch {}
+        declare function consume(value: unknown): void;
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        declare function consume(value: unknown): void;
+        declare const thenable: PromiseLike<number>;
+        try { consume(thenable); } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        try {
+          Promise.resolve(1).catch(() => 0);
+          Promise.resolve(2).then(() => 3);
+        } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        try {
+          try { Promise.resolve(1); } catch {}
+        } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        declare function consume(value: unknown): void;
+        declare const value: Promise<number> | undefined;
+        try { consume(value); } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        import { of } from 'rxjs';
+        try { of(1).pipe().subscribe(); } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { BehaviorSubject } from 'rxjs';
+        const state = new BehaviorSubject(0);
+        try { state.next(1); } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { Subject } from 'rxjs';
+        class State<T> extends Subject<T> {}
+        const state = new State<number>();
+        try { state.next(1); } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { Observable as Stream } from 'rxjs';
+        type Source<T> = Stream<T>;
+        declare const source: Source<number>;
+        try { source.subscribe(); } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { firstValueFrom, of } from 'rxjs';
+        try { firstValueFrom(of(1)); } catch {}
+      `,
+      options: [{ allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }, { messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { lastValueFrom, of } from 'rxjs';
+        try { lastValueFrom(of(1)); } catch {}
+      `,
+      options: [{ allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }, { messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { computed } from '@angular/core';
+        const value = computed(() => {
+          try { return JSON.parse('1'); } catch { return 0; }
+        });
+      `,
+      options: allowOnlySignalCheck,
+      errors: [{ messageId: 'signalContextNotAllowed' }],
+    },
+    {
+      code: `
+        import { effect as react } from '@angular/core';
+        react(() => {
+          try { JSON.parse('1'); } catch {}
+        });
+      `,
+      options: allowOnlySignalCheck,
+      errors: [{ messageId: 'signalContextNotAllowed' }],
+    },
+    {
+      code: `
+        import * as ng from '@angular/core';
+        ng.effect(() => {
+          try { JSON.parse('1'); } catch {}
+        });
+      `,
+      options: allowOnlySignalCheck,
+      errors: [{ messageId: 'signalContextNotAllowed' }],
+    },
+    {
+      code: `
+        try {
+          first();
+          second();
+          third();
+          fourth();
+        } catch {}
+        declare function first(): void;
+        declare function second(): void;
+        declare function third(): void;
+        declare function fourth(): void;
+      `,
+      options: allowOnlySizeCheck,
+      errors: [{ messageId: 'tooManyLines', data: { actual: 4, max: 3 } }],
+    },
+    {
+      code: `
+        try {
+          if (ready) {
+            work();
+          }
+        } catch {}
+        declare const ready: boolean;
+        declare function work(): void;
+      `,
+      options: [{ allowPromise: true, allowRxjs: true, allowInSignal: true, maxLines: 2 }],
+      errors: [{ messageId: 'tooManyLines', data: { actual: 3, max: 2 } }],
+    },
+    {
+      code: `
+        try {
+          const text = \`first
+
+          third\`;
+        } catch {}
+      `,
+      options: [{ allowPromise: true, allowRxjs: true, allowInSignal: true, maxLines: 2 }],
+      errors: [{ messageId: 'tooManyLines', data: { actual: 3, max: 2 } }],
+    },
+  ],
+});
+
+describe('restrict-try-block configuration', () => {
+  function verifyWithoutTypedLinting(options?: Record<string, unknown>) {
+    const linter = new Linter({ configType: 'flat' });
+    return linter.verify(
+      'try { JSON.parse(source); } catch {}',
+      [
+        {
+          files: ['**/*.ts'],
+          languageOptions: { parser },
+          plugins: { test: { rules: { 'restrict-try-block': rule as unknown as Rule.RuleModule } } },
+          rules: {
+            'test/restrict-try-block': options ? ['error', options] : 'error',
+          },
+        },
+      ],
+      { filename: 'file.ts' },
+    );
+  }
+
+  it('fails clearly when a typed check is enabled without parser services', () => {
+    expect(() => verifyWithoutTypedLinting()).toThrow(/type information/u);
+  });
+
+  it('rejects an invalid maxLines option through the rule schema', () => {
+    expect(() =>
+      verifyWithoutTypedLinting({
+        allowPromise: true,
+        allowRxjs: true,
+        allowInSignal: true,
+        maxLines: 0,
+      }),
+    ).toThrow(/should be >= 1/u);
+  });
+});


### PR DESCRIPTION
## Summary

- add a type-aware `restrict-try-block` rule
- reject Promise/RxJS work and Angular `computed`/`effect` contexts inside `try` by default
- limit try bodies to three physical code lines by default
- include the rule in `rdlabo.configs.recommended`
- restore and harden README rule-table generation

## Why

Broad try/catch blocks can hide Promise, RxJS, and Signal error-handling mistakes during review. This rule keeps synchronous exception boundaries small and directs asynchronous/reactive errors to their native error channels.

Consumers using the recommended preset will receive the rule automatically after updating the package.

## Validation

- `npm run update`
- `npm run lint`
- scripts TypeScript check
- all 24 Jest suites / 484 tests passed in isolated suite processes
- 32 focused edge-case tests for `restrict-try-block`
