### PR TITLE
Gracefully degrade try rule without type information

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const rdlabo = require('@rdlabo/eslint-plugin-rules');
 module.exports = tseslint.config(
   {
     files: ['**/*.ts'],
+    languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: __dirname } },
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,

--- a/docs/rules/restrict-try-block.md
+++ b/docs/rules/restrict-try-block.md
@@ -27,7 +27,7 @@ Promise.resolve()
 
 RxJS errors should be handled through the Observable error channel, such as `catchError()` or an explicit subscriber error handler.
 
-This is a type-aware rule. Configure typed linting, for example:
+Promise-like and RxJS type detection uses TypeScript type information when available. Without typed linting, those type-dependent checks are skipped instead of stopping ESLint; syntax-based `await`, Angular Signal context, and `maxLines` checks still run. Configure typed linting for full enforcement, for example:
 
 ```js
 languageOptions: {
@@ -53,6 +53,8 @@ languageOptions: {
 - `allowRxjs`: Allow values and operations backed by types declared by `rxjs`. This includes `Observable`, `Subject`, and their subclasses.
 - `allowInSignal`: Allow `try` inside inline Angular `computed()` and `effect()` callbacks. Aliased and namespace imports from `@angular/core` are recognized. Nested function and class bodies are separate execution boundaries.
 - `maxLines`: Maximum physical code lines in the `try` body, or `false` to disable the size check.
+
+`allowPromise: false` and `allowRxjs: false` are fully enforced when typed linting is configured. Without type information, only syntax-based checks such as `await` remain available for those categories.
 
 For `maxLines`, the outer braces, comments, and blank lines are excluded. A unique physical line containing any other token counts once. Internal braces and multiline tokens count, so formatting can affect the result intentionally: the rule keeps the boundary visually small as well as logically narrow.
 

--- a/src/rules/restrict-try-block.ts
+++ b/src/rules/restrict-try-block.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { ParserServices, ParserServicesWithTypeInformation, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type { Type } from 'typescript';
 import { isIntrinsicAnyType, isIntrinsicUnknownType, isThenableType } from 'ts-api-utils';
 
@@ -31,8 +31,23 @@ function isTraversalBoundary(node: TSESTree.Node): boolean {
   );
 }
 
-function isRelevantExpression(node: TSESTree.Node): node is TSESTree.Identifier | TSESTree.MemberExpression | TSESTree.CallExpression | TSESTree.NewExpression {
-  return node.type === 'Identifier' || node.type === 'MemberExpression' || node.type === 'CallExpression' || node.type === 'NewExpression';
+function isRelevantExpression(
+  node: TSESTree.Node,
+): node is
+  | TSESTree.Identifier
+  | TSESTree.MemberExpression
+  | TSESTree.CallExpression
+  | TSESTree.NewExpression
+  | TSESTree.ImportExpression
+  | TSESTree.TaggedTemplateExpression {
+  return (
+    node.type === 'Identifier' ||
+    node.type === 'MemberExpression' ||
+    node.type === 'CallExpression' ||
+    node.type === 'NewExpression' ||
+    node.type === 'ImportExpression' ||
+    node.type === 'TaggedTemplateExpression'
+  );
 }
 
 function isUnsafeTopType(type: Type): boolean {
@@ -51,6 +66,10 @@ function declarationComesFromRxjs(type: Type): boolean {
       return fileName.includes('/node_modules/rxjs/');
     }),
   );
+}
+
+function hasTypeInformation(services: Partial<ParserServices> | null | undefined): services is ParserServicesWithTypeInformation {
+  return Boolean(services?.program && services.esTreeNodeToTSNodeMap && services.tsNodeToESTreeNodeMap && services.getTypeAtLocation);
 }
 
 const rule: TSESLint.RuleModule<MessageIds, Options> = {
@@ -92,7 +111,8 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
     const options = { ...DEFAULT_OPTIONS, ...context.options[0] };
     const sourceCode = context.sourceCode;
     const needsTypeInformation = !options.allowPromise || !options.allowRxjs;
-    const services = needsTypeInformation ? ESLintUtils.getParserServices(context) : null;
+    const parserServices = sourceCode.parserServices;
+    const services = needsTypeInformation && hasTypeInformation(parserServices) ? parserServices : null;
     const checker = services?.program.getTypeChecker();
     const angularSignalCallbacks = new Set(['computed', 'effect']);
     const angularSignalNames = new Set<string>();
@@ -207,7 +227,7 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
           }
         }
 
-        if (!options.allowPromise || !promiseNode || !options.allowRxjs || !rxjsNode) {
+        if ((!options.allowPromise && !promiseNode) || (!options.allowRxjs && !rxjsNode)) {
           const keys = sourceCode.visitorKeys[node.type] ?? [];
           const record = node as unknown as Record<string, unknown>;
           for (const key of keys) {

--- a/tests/rules/restrict-try-block.ts
+++ b/tests/rules/restrict-try-block.ts
@@ -157,6 +157,23 @@ ruleTester.run('restrict-try-block', rule, {
     },
     {
       code: `
+        async function load() {
+          try { import('./feature'); } catch {}
+        }
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        declare function load(strings: TemplateStringsArray): Promise<number>;
+        try { load\`feature\`; } catch {}
+      `,
+      options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
         declare function consume(value: unknown): void;
         declare const thenable: PromiseLike<number>;
         try { consume(thenable); } catch {}
@@ -247,6 +264,39 @@ ruleTester.run('restrict-try-block', rule, {
     },
     {
       code: `
+        import { of } from 'rxjs';
+        try {
+          Promise.resolve(1);
+          of(1);
+        } catch {}
+      `,
+      options: [{ allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'promiseNotAllowed' }, { messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
+        import { of } from 'rxjs';
+        try {
+          of(1);
+          Promise.resolve(1);
+        } catch {}
+      `,
+      options: [{ allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }, { messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `
+        import { of } from 'rxjs';
+        try {
+          Promise.resolve(1);
+          of(1);
+        } catch {}
+      `,
+      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      errors: [{ messageId: 'rxjsNotAllowed' }],
+    },
+    {
+      code: `
         import { computed } from '@angular/core';
         const value = computed(() => {
           try { return JSON.parse('1'); } catch { return 0; }
@@ -319,10 +369,10 @@ ruleTester.run('restrict-try-block', rule, {
 });
 
 describe('restrict-try-block configuration', () => {
-  function verifyWithoutTypedLinting(options?: Record<string, unknown>) {
+  function verifyWithoutTypedLinting(code: string, options?: Record<string, unknown>) {
     const linter = new Linter({ configType: 'flat' });
     return linter.verify(
-      'try { JSON.parse(source); } catch {}',
+      code,
       [
         {
           files: ['**/*.ts'],
@@ -337,13 +387,50 @@ describe('restrict-try-block configuration', () => {
     );
   }
 
-  it('fails clearly when a typed check is enabled without parser services', () => {
-    expect(() => verifyWithoutTypedLinting()).toThrow(/type information/u);
+  it('skips type-dependent Promise and RxJS checks without typed linting', () => {
+    expect(
+      verifyWithoutTypedLinting(`
+        import { of } from 'rxjs';
+        try { Promise.resolve(of(1)); } catch {}
+      `),
+    ).toEqual([]);
+  });
+
+  it('skips dynamic import Promise detection without typed linting', () => {
+    expect(verifyWithoutTypedLinting("try { import('./feature'); } catch {}")).toEqual([]);
+  });
+
+  it('keeps syntax-based await checks without typed linting', () => {
+    expect(verifyWithoutTypedLinting('async function run() { try { await work(); } catch {} }')).toEqual([
+      expect.objectContaining({ messageId: 'promiseNotAllowed' }),
+    ]);
+  });
+
+  it('keeps Angular Signal context checks without typed linting', () => {
+    expect(
+      verifyWithoutTypedLinting(`
+        import { computed } from '@angular/core';
+        computed(() => { try { return JSON.parse('1'); } catch { return 0; } });
+      `),
+    ).toEqual([expect.objectContaining({ messageId: 'signalContextNotAllowed' })]);
+  });
+
+  it('keeps maxLines checks without typed linting', () => {
+    expect(
+      verifyWithoutTypedLinting(`
+        try {
+          first();
+          second();
+          third();
+          fourth();
+        } catch {}
+      `),
+    ).toEqual([expect.objectContaining({ messageId: 'tooManyLines' })]);
   });
 
   it('rejects an invalid maxLines option through the rule schema', () => {
     expect(() =>
-      verifyWithoutTypedLinting({
+      verifyWithoutTypedLinting('try { JSON.parse(source); } catch {}', {
         allowPromise: true,
         allowRxjs: true,
         allowInSignal: true,


### PR DESCRIPTION
## Summary

- make `restrict-try-block` skip only type-dependent Promise/RxJS checks when typed linting is unavailable
- preserve syntax-based `await`, Angular Signal context, and `maxLines` checks
- fix the traversal early-exit condition
- cover dynamic imports, Promise-returning tagged templates, category ordering, and untyped operation
- document typed-linting behavior and configure it in the recommended README example

## Root cause

The rule called `getParserServices()` unconditionally for its default options. Projects using the recommended preset without `projectService` or `project` therefore stopped linting with an exception after upgrading.

The traversal continuation condition also used disjunctions that could never all become false, so completed searches still traversed the entire try body.

## Impact

Existing OSS consumers can update without typed linting causing ESLint to crash. Typed projects retain full Promise/RxJS enforcement; untyped projects retain all syntax-based checks.

## Review

Senior review approved the final diff with no blockers after dynamic import and traversal regression coverage was added.

## Validation

- `npm run update`
- `npm run lint`
- all 24 Jest suites / 493 tests passed in isolated suite processes
- 41 focused `restrict-try-block` tests
- `git diff --check`
