### PR TITLE
Ban Promise.resolve escape hatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module.exports = tseslint.config(
 
 `rdlabo.configs.recommended` enables the fleet-common `@rdlabo/rules/*` preset:
 
-- TypeScript: `signal-use-as-signal`, `signal-use-as-signal-template`, `deny-import-from-ionic-module`, `implements-ionic-lifecycle`, `deny-soft-private-modifier`, `deny-overlay-create`, `prefer-modal-launcher`, `require-viewmodel`, `component-property-use-readonly` (`ignorePrivateProperties: true`), `no-component-method-except-lifecycle`, `restrict-try-block` (`allowPromise: false`, `allowRxjs: false`, `allowInSignal: false`, `maxLines: 3`)
+- TypeScript: `signal-use-as-signal`, `signal-use-as-signal-template`, `deny-import-from-ionic-module`, `implements-ionic-lifecycle`, `deny-soft-private-modifier`, `deny-overlay-create`, `prefer-modal-launcher`, `require-viewmodel`, `component-property-use-readonly` (`ignorePrivateProperties: true`), `no-component-method-except-lifecycle`, `restrict-try-block` (`allowPromise: false`, `allowPromiseResolve: false`, `allowRxjs: false`, `allowInSignal: false`, `maxLines: 3`)
 - Templates: `ionic-attr-type-check`, `deny-element` (common Ionic overlay tags), `prefer-disable-handler`
 
 `deny-constructor-di` is **not** included (deprecated; prefer Angular `inject()` migration).
@@ -97,7 +97,7 @@ module.exports = tseslint.config(
       '@rdlabo/rules/signal-use-as-signal': 'error',
       '@rdlabo/rules/signal-use-as-signal-template': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
-      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowPromiseResolve: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {
@@ -139,7 +139,7 @@ module.exports = tseslint.config(
 | [@rdlabo/rules/prefer-disable-handler](./docs/rules/prefer-disable-handler.md)                             | Require a wrapper method (default: disableHandler($event, work)) on configured element/event bindings to prevent double taps while async work runs                |      ❌      |
 | [@rdlabo/rules/prefer-modal-launcher](./docs/rules/prefer-modal-launcher.md)                               | Require `presentModal` calls to live inside a `launch*` launcher function.                                                                                        |      ❌      |
 | [@rdlabo/rules/require-viewmodel](./docs/rules/require-viewmodel.md)                                       | Enforce Component `new ViewModel(this)`, `ViewModelStore<ComponentType, Keys>` inheritance, and keep View APIs off ViewModel.                                     |      ❌      |
-| [@rdlabo/rules/restrict-try-block](./docs/rules/restrict-try-block.md)                                     | Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.                                                                       |      ❌      |
+| [@rdlabo/rules/restrict-try-block](./docs/rules/restrict-try-block.md)                                     | Restrict Promise, RxJS, Angular Signal contexts, `Promise.resolve()` escape hatches, and physical code lines inside try blocks.                                   |      ❌      |
 | [@rdlabo/rules/signal-use-as-signal-template](./docs/rules/signal-use-as-signal-template.md)               | Require () when accessing Angular Signals in templates                                                                                                            |      ❌      |
 | [@rdlabo/rules/signal-use-as-signal](./docs/rules/signal-use-as-signal.md)                                 | This plugin check to valid signal use as signal.                                                                                                                  |      ✅      |
 

--- a/docs/rules/restrict-try-block.md
+++ b/docs/rules/restrict-try-block.md
@@ -1,6 +1,6 @@
 # @rdlabo/rules/restrict-try-block
 
-> Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.
+> Restrict Promise, RxJS, Angular Signal contexts, `Promise.resolve()` escape hatches, and physical code lines inside try blocks.
 >
 > - ⭐️ This rule is included in `plugin:@rdlabo/rules/recommended` preset.
 
@@ -11,23 +11,27 @@ Restricts asynchronous/reactive processing and physical code lines inside `try` 
 This rule keeps `try` as a small boundary for synchronous exceptions. By default it reports:
 
 - `await` and expressions whose TypeScript type is Promise-like
+- `Promise.resolve()` calls anywhere, including chains used to convert synchronous exceptions into Promise rejections
 - expressions whose type or base type is declared by the `rxjs` package, including `Observable` and `Subject` variants
 - `try` statements inside Angular `computed()` and `effect()` callbacks
 - `try` bodies containing more than three physical code lines
 
-Only the `try` body is inspected. Its `catch` and `finally` clauses are not. Nested functions, classes, and nested `try` statements are separate execution boundaries and are not attributed to the outer `try`.
+For the `try`-specific checks, only the `try` body is inspected. Its `catch` and `finally` clauses are not. Nested functions, classes, and nested `try` statements are separate execution boundaries and are not attributed to the outer `try`. The `Promise.resolve()` check applies throughout the file.
 
-Promise rejections should normally be handled by a Promise error boundary such as `.catch()`. If a Promise producer can also throw synchronously, preserve that boundary explicitly:
+Promise rejections should normally be handled by a Promise error boundary such as `.catch()`. Do not manufacture that boundary with `Promise.resolve()` to move synchronous failures into the rejection channel:
 
 ```ts
+// incorrect
 Promise.resolve()
-  .then(() => makePromise())
+  .then(() => fallibleSynchronousWork())
   .catch(handleError);
 ```
 
+Keep a synchronous `try` boundary small and place it in the layer responsible for handling that failure. Return a value or an existing Promise directly instead of normalizing it with `Promise.resolve(value)`.
+
 RxJS errors should be handled through the Observable error channel, such as `catchError()` or an explicit subscriber error handler.
 
-Promise-like and RxJS type detection uses TypeScript type information when available. Without typed linting, those type-dependent checks are skipped instead of stopping ESLint; syntax-based `await`, Angular Signal context, and `maxLines` checks still run. Configure typed linting for full enforcement, for example:
+Promise-like and RxJS type detection uses TypeScript type information when available. Without typed linting, those type-dependent checks are skipped instead of stopping ESLint; syntax-based `await`, `Promise.resolve()`, Angular Signal context, and `maxLines` checks still run. Configure typed linting for full enforcement, for example:
 
 ```js
 languageOptions: {
@@ -43,6 +47,7 @@ languageOptions: {
 ```js
 {
   allowPromise: false,
+  allowPromiseResolve: false,
   allowRxjs: false,
   allowInSignal: false,
   maxLines: 3,
@@ -50,11 +55,14 @@ languageOptions: {
 ```
 
 - `allowPromise`: Allow Promise-like processing and `await` inside `try`.
+- `allowPromiseResolve`: Disable the dedicated file-wide `Promise.resolve()` check. Inside a `try` body, `allowPromise: true` is also required because the call is independently Promise-like processing.
 - `allowRxjs`: Allow values and operations backed by types declared by `rxjs`. This includes `Observable`, `Subject`, and their subclasses.
 - `allowInSignal`: Allow `try` inside inline Angular `computed()` and `effect()` callbacks. Aliased and namespace imports from `@angular/core` are recognized. Nested function and class bodies are separate execution boundaries.
 - `maxLines`: Maximum physical code lines in the `try` body, or `false` to disable the size check.
 
 `allowPromise: false` and `allowRxjs: false` are fully enforced when typed linting is configured. Without type information, only syntax-based checks such as `await` remain available for those categories.
+
+The `Promise.resolve()` check recognizes the unshadowed global `Promise` and explicit `globalThis.Promise`, including static bracket notation. It intentionally does not follow aliases. A locally declared or imported value named `Promise`, or a locally shadowed `globalThis`, is not treated as the built-in API.
 
 For `maxLines`, the outer braces, comments, and blank lines are excluded. A unique physical line containing any other token counts once. Internal braces and multiline tokens count, so formatting can affect the result intentionally: the rule keeps the boundary visually small as well as logically narrow.
 

--- a/scripts/lib/update-lib-configs-recommended.ts
+++ b/scripts/lib/update-lib-configs-recommended.ts
@@ -32,7 +32,7 @@ const recommended: Linter.Config[] = [
       '@rdlabo/rules/require-viewmodel': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
       '@rdlabo/rules/no-component-method-except-lifecycle': 'error',
-      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowPromiseResolve: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -21,7 +21,7 @@ const recommended: Linter.Config[] = [
       '@rdlabo/rules/require-viewmodel': 'error',
       '@rdlabo/rules/component-property-use-readonly': ['error', { ignorePrivateProperties: true }],
       '@rdlabo/rules/no-component-method-except-lifecycle': 'error',
-      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
+      '@rdlabo/rules/restrict-try-block': ['error', { allowPromise: false, allowPromiseResolve: false, allowRxjs: false, allowInSignal: false, maxLines: 3 }],
     },
   },
   {

--- a/src/rules/restrict-try-block.ts
+++ b/src/rules/restrict-try-block.ts
@@ -2,10 +2,11 @@ import { ParserServices, ParserServicesWithTypeInformation, TSESLint, TSESTree }
 import type { Type } from 'typescript';
 import { isIntrinsicAnyType, isIntrinsicUnknownType, isThenableType } from 'ts-api-utils';
 
-type MessageIds = 'promiseNotAllowed' | 'rxjsNotAllowed' | 'signalContextNotAllowed' | 'tooManyLines';
+type MessageIds = 'promiseNotAllowed' | 'promiseResolveNotAllowed' | 'rxjsNotAllowed' | 'signalContextNotAllowed' | 'tooManyLines';
 
 interface RuleOptions {
   allowPromise?: boolean;
+  allowPromiseResolve?: boolean;
   allowRxjs?: boolean;
   allowInSignal?: boolean;
   maxLines?: number | false;
@@ -15,6 +16,7 @@ type Options = [RuleOptions?];
 
 const DEFAULT_OPTIONS: Required<RuleOptions> = {
   allowPromise: false,
+  allowPromiseResolve: false,
   allowRxjs: false,
   allowInSignal: false,
   maxLines: 3,
@@ -54,6 +56,16 @@ function isUnsafeTopType(type: Type): boolean {
   return isIntrinsicAnyType(type) || isIntrinsicUnknownType(type);
 }
 
+function hasStaticPropertyName(node: TSESTree.MemberExpression, name: string): boolean {
+  if (!node.computed) {
+    return node.property.type === 'Identifier' && node.property.name === name;
+  }
+  if (node.property.type === 'Literal') {
+    return node.property.value === name;
+  }
+  return node.property.type === 'TemplateLiteral' && node.property.expressions.length === 0 && node.property.quasis[0]?.value.cooked === name;
+}
+
 function typeParts(type: Type): readonly Type[] {
   return type.isUnionOrIntersection() ? type.types : [type];
 }
@@ -76,12 +88,14 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
   defaultOptions: [DEFAULT_OPTIONS],
   meta: {
     docs: {
-      description: 'Restrict Promise, RxJS, Angular Signal contexts, and physical code lines inside try blocks.',
+      description: 'Restrict Promise, RxJS, Angular Signal contexts, `Promise.resolve()` escape hatches, and physical code lines inside try blocks.',
       url: '',
     },
     messages: {
       promiseNotAllowed:
-        'Promise/thenable processing is not allowed inside a try block. Use a Promise error boundary such as `.catch()`; wrap the producer in `Promise.resolve().then()` when it may throw synchronously.',
+        'Promise/thenable processing is not allowed inside a try block. Keep the try block limited to the synchronous operation that can throw, and handle Promise rejections outside it.',
+      promiseResolveNotAllowed:
+        '`Promise.resolve()` is not allowed. Return a value or an existing Promise directly, and use a small, explicit synchronous error boundary at the responsible layer when work can throw.',
       rxjsNotAllowed:
         'RxJS processing is not allowed inside a try block. Handle its error channel with `catchError()` or an explicit subscriber error handler.',
       signalContextNotAllowed:
@@ -93,6 +107,7 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
         type: 'object',
         properties: {
           allowPromise: { type: 'boolean' },
+          allowPromiseResolve: { type: 'boolean' },
           allowRxjs: { type: 'boolean' },
           allowInSignal: { type: 'boolean' },
           maxLines: {
@@ -117,6 +132,51 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
     const angularSignalCallbacks = new Set(['computed', 'effect']);
     const angularSignalNames = new Set<string>();
     const angularCoreNamespaces = new Set<string>();
+
+    function isTypeOnlyDefinition(definition: TSESLint.Scope.Definition): boolean {
+      if (definition.type === TSESLint.Scope.DefinitionType.Type) {
+        return true;
+      }
+      return (
+        definition.type === TSESLint.Scope.DefinitionType.ImportBinding &&
+        ((definition.node.type === 'ImportSpecifier' && definition.node.importKind === 'type') ||
+          (definition.parent.type === 'ImportDeclaration' && definition.parent.importKind === 'type'))
+      );
+    }
+
+    function isUnshadowedGlobal(node: TSESTree.Identifier): boolean {
+      let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(node);
+      while (scope) {
+        const variable = scope.set.get(node.name);
+        if (variable && variable.defs.some((definition) => !isTypeOnlyDefinition(definition))) {
+          return false;
+        }
+        scope = scope.upper;
+      }
+      return true;
+    }
+
+    function isGlobalPromiseObject(node: TSESTree.Expression): boolean {
+      if (node.type === 'Identifier') {
+        return node.name === 'Promise' && isUnshadowedGlobal(node);
+      }
+      return (
+        node.type === 'MemberExpression' &&
+        hasStaticPropertyName(node, 'Promise') &&
+        node.object.type === 'Identifier' &&
+        node.object.name === 'globalThis' &&
+        isUnshadowedGlobal(node.object)
+      );
+    }
+
+    function isPromiseResolveCall(node: TSESTree.Node): node is TSESTree.CallExpression {
+      return (
+        node.type === 'CallExpression' &&
+        node.callee.type === 'MemberExpression' &&
+        hasStaticPropertyName(node.callee, 'resolve') &&
+        isGlobalPromiseObject(node.callee.object)
+      );
+    }
 
     for (const statement of sourceCode.ast.body) {
       if (statement.type !== 'ImportDeclaration' || statement.source.value !== '@angular/core') {
@@ -217,6 +277,10 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
           promiseNode = node;
         }
 
+        if (!options.allowPromise && !promiseNode && isPromiseResolveCall(node)) {
+          promiseNode = node;
+        }
+
         if (services && checker && isRelevantExpression(node) && ((!options.allowPromise && !promiseNode) || (!options.allowRxjs && !rxjsNode))) {
           const type = services.getTypeAtLocation(node);
           if (!options.allowPromise && !promiseNode && isPromiseLike(node, type)) {
@@ -249,7 +313,32 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
       return { promiseNode, rxjsNode };
     }
 
+    function isInsideTryBody(node: TSESTree.Node): boolean {
+      let current: TSESTree.Node | undefined = node;
+      while (current.parent) {
+        if (current.parent.type === 'TryStatement') {
+          return current.parent.block === current;
+        }
+        if (
+          current.parent.type === 'FunctionDeclaration' ||
+          current.parent.type === 'FunctionExpression' ||
+          current.parent.type === 'ArrowFunctionExpression' ||
+          current.parent.type === 'ClassDeclaration' ||
+          current.parent.type === 'ClassExpression'
+        ) {
+          return false;
+        }
+        current = current.parent;
+      }
+      return false;
+    }
+
     return {
+      CallExpression(node) {
+        if (!options.allowPromiseResolve && isPromiseResolveCall(node) && (options.allowPromise || !isInsideTryBody(node))) {
+          context.report({ node, messageId: 'promiseResolveNotAllowed' });
+        }
+      },
       TryStatement(node) {
         const { promiseNode, rxjsNode } = inspectTryBlock(node.block);
 

--- a/tests/rules/restrict-try-block.ts
+++ b/tests/rules/restrict-try-block.ts
@@ -13,11 +13,38 @@ const ruleTester = new RuleTester({
   },
 });
 
-const allowOnlySizeCheck = [{ allowPromise: true, allowRxjs: true, allowInSignal: true }] as const;
-const allowOnlySignalCheck = [{ allowPromise: true, allowRxjs: true, maxLines: false }] as const;
+const allowOnlySizeCheck = [{ allowPromise: true, allowPromiseResolve: true, allowRxjs: true, allowInSignal: true }] as const;
+const allowOnlySignalCheck = [{ allowPromise: true, allowPromiseResolve: true, allowRxjs: true, maxLines: false }] as const;
 
 ruleTester.run('restrict-try-block', rule, {
   valid: [
+    {
+      code: `Promise.resolve().then(run);`,
+      options: [{ allowPromiseResolve: true }],
+    },
+    {
+      code: `try { Promise.resolve(value); } catch {}`,
+      options: [{ allowPromise: true, allowPromiseResolve: true }],
+    },
+    `
+      function run(Promise: { resolve(value?: unknown): void }) {
+        Promise.resolve();
+      }
+      const Promise = { resolve(value?: unknown) {} };
+      Promise.resolve(1);
+    `,
+    `
+      function run(globalThis: { Promise: { resolve(): void } }) {
+        globalThis.Promise.resolve();
+      }
+    `,
+    `
+      const Promise = { resolve() {} };
+      function run() {
+        type Promise = string;
+        Promise.resolve();
+      }
+    `,
     `
       function parse(source: string) {
         try {
@@ -42,8 +69,8 @@ ruleTester.run('restrict-try-block', rule, {
     {
       code: `
         try {
-          const later = async () => Promise.resolve(1);
-          class Later { async run() { return Promise.resolve(2); } }
+          const later = async () => 1;
+          class Later { async run() { return 2; } }
         } catch {}
       `,
       options: [{ allowRxjs: true, allowInSignal: true, maxLines: false }],
@@ -77,8 +104,9 @@ ruleTester.run('restrict-try-block', rule, {
     {
       code: `
         async function run() {
-          try { await Promise.resolve(1); } catch {}
+          try { await work(); } catch {}
         }
+        declare function work(): Promise<number>;
       `,
       options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
     },
@@ -118,12 +146,14 @@ ruleTester.run('restrict-try-block', rule, {
       code: `
         async function run() {
           try { doWork(); } catch {
-            await Promise.resolve();
+            await recover();
           } finally {
-            Promise.resolve();
+            cleanup();
           }
         }
         declare function doWork(): void;
+        declare function recover(): Promise<void>;
+        declare function cleanup(): void;
       `,
     },
     {
@@ -137,6 +167,62 @@ ruleTester.run('restrict-try-block', rule, {
     },
   ],
   invalid: [
+    {
+      code: `Promise.resolve().then(() => doWork()).catch(handleError);`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `Promise['resolve']().then(() => doWork());`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `Promise.resolve(value);`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `globalThis.Promise.resolve(value);`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `globalThis['Promise'][\`resolve\`]();`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `type Promise = string; Promise.resolve();`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `interface Promise<T> {} Promise.resolve();`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `type globalThis = string; globalThis.Promise.resolve();`,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `
+        try { doWork(); } catch {
+          Promise.resolve().then(handleError);
+        }
+      `,
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
+    {
+      code: `
+        try { Promise.resolve(); } catch {}
+      `,
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `try { Promise.resolve(); } catch {}`,
+      options: [{ allowPromiseResolve: true }],
+      errors: [{ messageId: 'promiseNotAllowed' }],
+    },
+    {
+      code: `try { Promise.resolve(); } catch {}`,
+      options: [{ allowPromise: true }],
+      errors: [{ messageId: 'promiseResolveNotAllowed' }],
+    },
     {
       code: `
         async function run() {
@@ -292,7 +378,7 @@ ruleTester.run('restrict-try-block', rule, {
           of(1);
         } catch {}
       `,
-      options: [{ allowPromise: true, allowInSignal: true, maxLines: false }],
+      options: [{ allowPromise: true, allowPromiseResolve: true, allowInSignal: true, maxLines: false }],
       errors: [{ messageId: 'rxjsNotAllowed' }],
     },
     {
@@ -391,7 +477,22 @@ describe('restrict-try-block configuration', () => {
     expect(
       verifyWithoutTypedLinting(`
         import { of } from 'rxjs';
-        try { Promise.resolve(of(1)); } catch {}
+        declare function consume(value: unknown): void;
+        try { consume(of(1)); } catch {}
+      `),
+    ).toEqual([]);
+  });
+
+  it('keeps Promise.resolve checks without typed linting', () => {
+    expect(verifyWithoutTypedLinting('Promise.resolve(value);')).toEqual([expect.objectContaining({ messageId: 'promiseResolveNotAllowed' })]);
+  });
+
+  it('does not report a shadowed Promise without typed linting', () => {
+    expect(
+      verifyWithoutTypedLinting(`
+        function run(Promise: { resolve(): void }) {
+          Promise.resolve();
+        }
       `),
     ).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- ban built-in `Promise.resolve(...)` throughout files under `restrict-try-block`
- detect direct and `globalThis.Promise` access, including static bracket notation
- avoid false positives for locally shadowed values while respecting TypeScript's separate type/value namespaces
- add `allowPromiseResolve` and document its interaction with `allowPromise`
- update the recommended config, generated documentation, and rule metadata

## Why

`Promise.resolve().then(...)` was increasingly used to move synchronous failures into the Promise rejection channel and bypass the intended small, explicit synchronous error boundary enforced by the try/catch rule. The rule now enforces the architectural boundary directly instead of recommending that escape hatch.

## Impact

The recommended preset reports built-in `Promise.resolve(...)` calls anywhere in a file. Projects that intentionally require the API can disable the dedicated check with `allowPromiseResolve: true`; calls inside `try` also require `allowPromise: true`.

## Validation

- `npm run lint`
- `npm test -- --runInBand` (24 suites, 512 tests)
- `git diff --check`
- manager review: approved
- independent third-party review: approved
