### PR TITLE
Fix recommended config template scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,15 @@ const rdlabo = require('@rdlabo/eslint-plugin-rules');
 
 module.exports = tseslint.config(
   {
-    files: ['**/*.ts'],
-    languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: __dirname } },
-    extends: [
-      eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      ...tseslint.configs.stylistic,
-      ...angular.configs.tsRecommended,
-      ...rdlabo.configs.recommended,
-    ],
     plugins: {
       '@rdlabo/rules': rdlabo,
     },
+  },
+  ...rdlabo.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: __dirname } },
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended, ...tseslint.configs.stylistic, ...angular.configs.tsRecommended],
     processor: angular.processInlineTemplates,
     rules: {
       // repo-specific overrides (selectors, restricted imports, etc.)
@@ -59,13 +56,15 @@ module.exports = tseslint.config(
   },
   {
     files: ['**/*.html'],
-    extends: [...angular.configs.templateRecommended, ...angular.configs.templateAccessibility, ...rdlabo.configs.recommended],
-    plugins: {
-      '@rdlabo/rules': rdlabo,
-    },
+    extends: [...angular.configs.templateRecommended, ...angular.configs.templateAccessibility],
   },
 );
 ```
+
+`rdlabo.configs.recommended` contains separate TypeScript and HTML configs. Keep
+it at the top level as shown above; placing it inside a scoped `extends` causes
+`typescript-eslint`'s config helper to replace its internal `files` selectors
+and can enable TypeScript-only rules for Angular templates.
 
 `rdlabo.configs.recommended` enables the fleet-common `@rdlabo/rules/*` preset:
 

--- a/scripts/lib/update-lib-configs-recommended.ts
+++ b/scripts/lib/update-lib-configs-recommended.ts
@@ -15,7 +15,8 @@ import type { Linter } from 'eslint';
 
 /**
  * Flat ESLint recommended preset for Ionic + Angular fleet apps.
- * Spread via \`extends: [...rdlabo.configs.recommended]\` after registering the plugin.
+ * Spread at the top level after registering the plugin so the TypeScript and
+ * template \`files\` selectors remain intact.
  */
 const recommended: Linter.Config[] = [
   {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -4,7 +4,8 @@ import type { Linter } from 'eslint';
 
 /**
  * Flat ESLint recommended preset for Ionic + Angular fleet apps.
- * Spread via `extends: [...rdlabo.configs.recommended]` after registering the plugin.
+ * Spread at the top level after registering the plugin so the TypeScript and
+ * template `files` selectors remain intact.
  */
 const recommended: Linter.Config[] = [
   {

--- a/src/rules/restrict-try-block.ts
+++ b/src/rules/restrict-try-block.ts
@@ -123,6 +123,13 @@ const rule: TSESLint.RuleModule<MessageIds, Options> = {
     type: 'problem',
   },
   create(context) {
+    // Angular's template parser exposes a template root instead of an ESTree
+    // Program. This rule is TypeScript-only, but guard against a flat-config
+    // composition accidentally enabling it for an HTML template.
+    if (!Array.isArray(context.sourceCode.ast.body)) {
+      return {};
+    }
+
     const options = { ...DEFAULT_OPTIONS, ...context.options[0] };
     const sourceCode = context.sourceCode;
     const needsTypeInformation = !options.allowPromise || !options.allowRxjs;

--- a/tests/rules/restrict-try-block.ts
+++ b/tests/rules/restrict-try-block.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from '@angular-eslint/test-utils';
+import * as templateParser from '@angular-eslint/template-parser';
 import { Linter, Rule } from 'eslint';
 import { resolve } from 'path';
 import { parser } from 'typescript-eslint';
@@ -538,5 +539,23 @@ describe('restrict-try-block configuration', () => {
         maxLines: 0,
       }),
     ).toThrow(/should be >= 1/u);
+  });
+
+  it('does not crash when accidentally enabled for an Angular template', () => {
+    const linter = new Linter({ configType: 'flat' });
+    const messages = linter.verify(
+      '<div>{{ value }}</div>',
+      [
+        {
+          files: ['**/*.html'],
+          languageOptions: { parser: templateParser },
+          plugins: { test: { rules: { 'restrict-try-block': rule as unknown as Rule.RuleModule } } },
+          rules: { 'test/restrict-try-block': 'error' },
+        },
+      ],
+      { filename: 'file.html' },
+    );
+
+    expect(messages).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- document the recommended preset as a top-level flat config so its TypeScript and HTML file selectors remain intact
- guard `restrict-try-block` when it is accidentally enabled for an Angular template AST
- add a regression test covering Angular template parsing

## Root cause

`rdlabo.configs.recommended` contains separate TypeScript and HTML configs. When the whole preset was spread inside a scoped `extends`, the `typescript-eslint` config helper replaced the preset's internal `files` selectors with the outer selector. In the HTML block, this enabled TypeScript-only rules such as `restrict-try-block` for Angular templates, where `sourceCode.ast.body` is not an ESTree program body.

## Impact

Consumers following the README configuration no longer load TypeScript-only rules for HTML templates. The rule also fails safely if a downstream config accidentally applies it to an Angular template.

## Validation

- `npm test -- --runInBand` — 24 suites, 513 tests passed
- `npm run build -- --noEmit`
- `npm run lint:eslint`
- `npm run lint:prettier`
